### PR TITLE
Update Ktor to 2.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,13 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.ktor:ktor-server-netty:1.6.7'
-    implementation 'io.ktor:ktor-websockets:1.6.7'
-    implementation 'io.ktor:ktor-serialization:1.6.7'
+    implementation 'io.ktor:ktor-server-netty:2.0.2'
+    implementation 'io.ktor:ktor-server-websockets:2.0.2'
+    implementation 'io.ktor:ktor-server-content-negotiation:2.0.2'
+    implementation 'io.ktor:ktor-serialization-kotlinx-json:2.0.2'
+    implementation 'io.ktor:ktor-server-status-pages:2.0.2'
+    implementation 'io.ktor:ktor-server-call-id:2.0.2'
+    implementation 'io.ktor:ktor-server-double-receive:2.0.2'
 
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2'
     implementation "com.charleskorn.kaml:kaml:0.36.0"

--- a/build.gradle
+++ b/build.gradle
@@ -22,12 +22,11 @@ dependencies {
     implementation 'io.ktor:ktor-server-status-pages:2.0.2'
     implementation 'io.ktor:ktor-server-call-id:2.0.2'
     implementation 'io.ktor:ktor-server-double-receive:2.0.2'
+    implementation 'io.ktor:ktor-server-call-logging:2.0.2'
 
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2'
     implementation "com.charleskorn.kaml:kaml:0.36.0"
     implementation 'org.valiktor:valiktor-core:0.12.0'
-
-    implementation 'com.koriit.kotlin:ktor-logging:0.4.0'
 
     implementation 'org.litote.kmongo:kmongo-coroutine-serialization:4.2.8'
     implementation 'org.litote.kmongo:kmongo-id:4.2.8'

--- a/src/main/kotlin/Server.kt
+++ b/src/main/kotlin/Server.kt
@@ -27,6 +27,7 @@ import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import io.ktor.server.plugins.callid.*
+import io.ktor.server.plugins.callloging.*
 import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.plugins.doublereceive.*
 import io.ktor.server.plugins.statuspages.*
@@ -60,6 +61,8 @@ class Server {
             json()
         }
 
+        install(CallLogging)
+
         install(StatusPages) {
             exception<ApiException> { call, ex ->
                 call.respond(ex.statusCode, ex.response)
@@ -70,7 +73,6 @@ class Server {
                     HttpStatusCode.InternalServerError,
                     InternalServerErrorException().response
                 )
-//                log.error(cause)
                 cause.printStackTrace()
             }
 
@@ -85,13 +87,6 @@ class Server {
         install(DoubleReceive) {
             cacheRawRequest = false
         }
-
-//        install(Logging) {
-//            logRequests = true
-//            logResponses = true
-//            logBody = false
-//            logHeaders = false
-//        }
 
         // Connect to database
         Database.database

--- a/src/main/kotlin/Server.kt
+++ b/src/main/kotlin/Server.kt
@@ -20,17 +20,18 @@
 
 package network.warzone.api
 
-import com.korrit.kotlin.ktor.features.logging.Logging
 import http.player.playerRoutes
-import io.ktor.application.*
-import io.ktor.features.*
 import io.ktor.http.*
-import io.ktor.response.*
-import io.ktor.serialization.*
+import io.ktor.serialization.kotlinx.json.*
+import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
-import io.ktor.util.*
-import io.ktor.websocket.*
+import io.ktor.server.plugins.callid.*
+import io.ktor.server.plugins.contentnegotiation.*
+import io.ktor.server.plugins.doublereceive.*
+import io.ktor.server.plugins.statuspages.*
+import io.ktor.server.response.*
+import io.ktor.server.websocket.*
 import network.warzone.api.database.Database
 import network.warzone.api.http.ApiException
 import network.warzone.api.http.InternalServerErrorException
@@ -47,8 +48,6 @@ import network.warzone.api.http.tag.tagRoutes
 import network.warzone.api.socket.initSocketHandler
 import java.util.*
 
-//import com.koriit.kotlin
-
 fun main() {
     embeddedServer(Netty, host = Config.listenHost, port = Config.listenPort) {
         Server().apply { main() }
@@ -62,16 +61,17 @@ class Server {
         }
 
         install(StatusPages) {
-            exception<ApiException> { ex ->
+            exception<ApiException> { call, ex ->
                 call.respond(ex.statusCode, ex.response)
             }
 
-            exception<Throwable> { cause ->
+            exception<Throwable> { call, cause ->
                 call.respond(
                     HttpStatusCode.InternalServerError,
                     InternalServerErrorException().response
                 )
-                log.error(cause)
+//                log.error(cause)
+                cause.printStackTrace()
             }
 
         }
@@ -83,20 +83,18 @@ class Server {
         }
 
         install(DoubleReceive) {
-            receiveEntireContent = true
+            cacheRawRequest = false
         }
 
-        install(Logging) {
-            logRequests = true
-            logResponses = true
-            logBody = false
-            logHeaders = false
-        }
+//        install(Logging) {
+//            logRequests = true
+//            logResponses = true
+//            logBody = false
+//            logHeaders = false
+//        }
 
         // Connect to database
         Database.database
-
-
 
         install(WebSockets)
 

--- a/src/main/kotlin/http/broadcast/BroadcastRoutes.kt
+++ b/src/main/kotlin/http/broadcast/BroadcastRoutes.kt
@@ -1,8 +1,8 @@
 package network.warzone.api.http.broadcast
 
-import io.ktor.application.*
-import io.ktor.response.*
-import io.ktor.routing.*
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
 import network.warzone.api.Config
 
 fun Route.manageBroadcasts() {

--- a/src/main/kotlin/http/leaderboard/LeaderboardRoutes.kt
+++ b/src/main/kotlin/http/leaderboard/LeaderboardRoutes.kt
@@ -1,8 +1,8 @@
 package network.warzone.api.http.leaderboard
 
-import io.ktor.application.*
-import io.ktor.response.*
-import io.ktor.routing.*
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
 import network.warzone.api.http.UnauthorizedException
 import network.warzone.api.http.ValidationException
 import network.warzone.api.socket.leaderboard.LeaderboardPeriod

--- a/src/main/kotlin/http/level/LevelRoutes.kt
+++ b/src/main/kotlin/http/level/LevelRoutes.kt
@@ -1,8 +1,8 @@
 package network.warzone.api.http.level
 
-import io.ktor.application.*
-import io.ktor.response.*
-import io.ktor.routing.*
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
 import network.warzone.api.Config
 
 fun Route.levelColors() {

--- a/src/main/kotlin/http/map/MapRoutes.kt
+++ b/src/main/kotlin/http/map/MapRoutes.kt
@@ -1,8 +1,8 @@
 package network.warzone.api.http.map
 
-import io.ktor.application.*
-import io.ktor.response.*
-import io.ktor.routing.*
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
 import network.warzone.api.database.Database
 import network.warzone.api.database.findById
 import network.warzone.api.database.findByName

--- a/src/main/kotlin/http/player/PlayerRoutes.kt
+++ b/src/main/kotlin/http/player/PlayerRoutes.kt
@@ -1,9 +1,9 @@
 package http.player
 
-import io.ktor.application.*
+import io.ktor.server.application.*
 import io.ktor.http.*
-import io.ktor.response.*
-import io.ktor.routing.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
 import network.warzone.api.Config
 import network.warzone.api.database.Database
 import network.warzone.api.database.PlayerCache

--- a/src/main/kotlin/http/punishment/PunishmentRoutes.kt
+++ b/src/main/kotlin/http/punishment/PunishmentRoutes.kt
@@ -1,8 +1,8 @@
 package network.warzone.api.http.punishment
 
-import io.ktor.application.*
-import io.ktor.response.*
-import io.ktor.routing.*
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
 import network.warzone.api.Config
 import network.warzone.api.database.Database
 import network.warzone.api.database.findById

--- a/src/main/kotlin/http/rank/RankRoutes.kt
+++ b/src/main/kotlin/http/rank/RankRoutes.kt
@@ -1,8 +1,8 @@
 package network.warzone.api.http.rank
 
-import io.ktor.application.*
-import io.ktor.response.*
-import io.ktor.routing.*
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
 import network.warzone.api.database.*
 import network.warzone.api.database.models.Player
 import network.warzone.api.database.models.Rank

--- a/src/main/kotlin/http/report/ReportRoutes.kt
+++ b/src/main/kotlin/http/report/ReportRoutes.kt
@@ -1,8 +1,8 @@
 package network.warzone.api.http.report
 
-import io.ktor.application.*
-import io.ktor.response.*
-import io.ktor.routing.*
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
 import network.warzone.api.util.WebhookUtil
 import network.warzone.api.util.protected
 import network.warzone.api.util.validate

--- a/src/main/kotlin/http/server/ServerRoutes.kt
+++ b/src/main/kotlin/http/server/ServerRoutes.kt
@@ -1,8 +1,8 @@
 package network.warzone.api.http.server
 
-import io.ktor.application.*
-import io.ktor.response.*
-import io.ktor.routing.*
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
 import network.warzone.api.database.Database
 import network.warzone.api.database.MatchCache
 import network.warzone.api.database.PlayerCache

--- a/src/main/kotlin/http/status/StatusRoutes.kt
+++ b/src/main/kotlin/http/status/StatusRoutes.kt
@@ -1,9 +1,9 @@
 package network.warzone.api.http.status
 
-import io.ktor.application.*
+import io.ktor.server.application.*
 import io.ktor.http.*
-import io.ktor.response.*
-import io.ktor.routing.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
 import kotlin.random.Random
 import kotlin.random.nextInt
 import kotlin.text.get

--- a/src/main/kotlin/http/tag/TagRoutes.kt
+++ b/src/main/kotlin/http/tag/TagRoutes.kt
@@ -1,8 +1,8 @@
 package network.warzone.api.http.tag
 
-import io.ktor.application.*
-import io.ktor.response.*
-import io.ktor.routing.*
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
 import network.warzone.api.database.*
 import network.warzone.api.database.models.Player
 import network.warzone.api.database.models.Tag

--- a/src/main/kotlin/socket/SocketHandler.kt
+++ b/src/main/kotlin/socket/SocketHandler.kt
@@ -1,9 +1,8 @@
 package network.warzone.api.socket
 
-import io.ktor.application.*
-import io.ktor.http.cio.websocket.*
-import io.ktor.routing.*
-import io.ktor.util.*
+import io.ktor.server.application.*
+import io.ktor.server.routing.*
+import io.ktor.server.websocket.*
 import io.ktor.websocket.*
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
@@ -29,7 +28,7 @@ fun Application.initSocketHandler() {
 
             // Server ID already connected
             if (ConnectedServers.any { it.id == serverId }) {
-                log.warn("Server ID '$serverId' attempting to connect twice! Closing new connection...")
+                println("Server ID '$serverId' attempting to connect twice! Closing new connection...")
                 return@webSocket this.close(
                     CloseReason(
                         CloseReason.Codes.VIOLATED_POLICY,
@@ -40,7 +39,7 @@ fun Application.initSocketHandler() {
 
             val server = ServerContext(serverId, this)
             ConnectedServers += server
-            log.info("Server '${server.id}' connected to socket server")
+            println("Server '${server.id}' connected to socket server")
 
             val router = SocketRouter(server)
 
@@ -53,7 +52,7 @@ fun Application.initSocketHandler() {
                     val eventName = json["e"]?.jsonPrimitive?.content ?: throw RuntimeException("Invalid event name")
                     val data = json["d"]?.jsonObject ?: throw RuntimeException("Invalid event data")
 
-                    log.info("[$serverId:$eventName] $data")
+                    println("[$serverId:$eventName] $data")
 
                     val eventType = EventType.valueOf(eventName)
 
@@ -61,10 +60,10 @@ fun Application.initSocketHandler() {
                     server.lastAliveTime = Date().time
                 }
             } catch (err: Exception) {
-                log.error(err)
+                err.printStackTrace()
             } finally {
                 ConnectedServers -= server
-                log.info("Server '${server.id}' disconnected from socket server")
+                println("Server '${server.id}' disconnected from socket server")
             }
         }
     }

--- a/src/main/kotlin/socket/server/ServerContext.kt
+++ b/src/main/kotlin/socket/server/ServerContext.kt
@@ -1,6 +1,6 @@
 package network.warzone.api.socket.server
 
-import io.ktor.http.cio.websocket.*
+import io.ktor.server.websocket.*
 import io.ktor.websocket.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/src/main/kotlin/util/AuthUtil.kt
+++ b/src/main/kotlin/util/AuthUtil.kt
@@ -1,7 +1,7 @@
 package network.warzone.api.util
 
-import io.ktor.application.*
-import io.ktor.request.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
 import io.ktor.util.pipeline.*
 import network.warzone.api.Config
 import network.warzone.api.http.UnauthorizedException

--- a/src/main/kotlin/util/ValidationUtil.kt
+++ b/src/main/kotlin/util/ValidationUtil.kt
@@ -1,8 +1,7 @@
 package network.warzone.api.util
 
-import io.ktor.application.*
-import io.ktor.request.*
-import io.ktor.util.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
 import io.ktor.util.pipeline.*
 import network.warzone.api.http.ApiException
 import network.warzone.api.http.ValidationException
@@ -24,7 +23,7 @@ suspend inline fun <reified T : Any> validate(context: PipelineContext<Unit, App
         context.application.log.warn(ex.message)
         throw ex
     } catch (ex: Exception) {
-        context.application.log.error(ex)
+        context.application.log.error(ex.toString())
         throw ValidationException("Validation failed. Ensure the JSON body only contains relevant keys.")
     }
 }


### PR DESCRIPTION
- Upgrades Ktor (HTTP and WebSocket library) to new major version, [2.0.2](https://blog.jetbrains.com/ktor/2022/04/11/ktor-2-0-released/)
- Appears to work fine during manual testing on private Warzone server
- `println()` is now used for most logs, but HTTP requests are still logged with a Ktor plugin
- Should hopefully fix issues of connection stability between Mars and Mars API, but those are more obvious on production
- Ktor Client 2 (for the Mars plugin) was also released but it does not appear necessary to use